### PR TITLE
feat: blacklist filter for exceptions

### DIFF
--- a/Classes/Domain/Configuration/Configuration.php
+++ b/Classes/Domain/Configuration/Configuration.php
@@ -14,6 +14,7 @@ class Configuration
     protected string $environment = "Production";
     protected string $release = "1.0.0";
     protected float $traces_sample_rate = 0.0;
+    protected string $blacklist_pattern = "";
 
     /**
      * Configuration constructor.
@@ -98,5 +99,10 @@ class Configuration
     public function getTracesSampleRate(): float
     {
         return $this->traces_sample_rate;
+    }
+
+    public function getBlacklistPattern(): string
+    {
+        return $this->blacklist_pattern;
     }
 }

--- a/Classes/Handler/DebugExceptionHandler.php
+++ b/Classes/Handler/DebugExceptionHandler.php
@@ -3,6 +3,7 @@
 namespace Jops\TYPO3\Sentry\Handler;
 
 use Jops\TYPO3\Sentry\Domain\Configuration\Configuration;
+use Jops\TYPO3\Sentry\Service\Blacklist;
 use Jops\TYPO3\Sentry\Service\SentryService;
 use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -14,6 +15,12 @@ class DebugExceptionHandler extends \TYPO3\CMS\Core\Error\DebugExceptionHandler
     public function handleException(Throwable $exception): void
     {
         $configuration = GeneralUtility::makeInstance(Configuration::class);
+
+        // Check weather the exception is excluded
+        if (Blacklist::isExcluded(get_class($exception))) {
+            parent::handleException($exception);
+            return;
+        }
 
         $dsn = $configuration->getDsn();
         if ($dsn === '' || $dsn === '0') {

--- a/Classes/Handler/ProductionExceptionHandler.php
+++ b/Classes/Handler/ProductionExceptionHandler.php
@@ -3,6 +3,7 @@
 namespace Jops\TYPO3\Sentry\Handler;
 
 use Jops\TYPO3\Sentry\Domain\Configuration\Configuration;
+use Jops\TYPO3\Sentry\Service\Blacklist;
 use Jops\TYPO3\Sentry\Service\SentryService;
 use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -14,6 +15,11 @@ class ProductionExceptionHandler extends \TYPO3\CMS\Core\Error\ProductionExcepti
     public function handleException(Throwable $exception): void
     {
         $configuration = GeneralUtility::makeInstance(Configuration::class);
+
+        // Check weather the exception is excluded
+        if (Blacklist::isExcluded(get_class($exception))) {
+            return;
+        }
 
         $dsn = $configuration->getDsn();
         if ($dsn === '' || $dsn === '0') {

--- a/Classes/Service/Blacklist.php
+++ b/Classes/Service/Blacklist.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Jops\TYPO3\Sentry\Service;
+
+use Jops\TYPO3\Sentry\Domain\Configuration\Configuration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class Blacklist
+{
+    /**
+     * Check weather the given string gets matched by the configured blacklist regex.
+     * If the blacklist regex is empty, this will always return false.
+     */
+    public static function isExcluded(string $className): bool
+    {
+        $configuration = GeneralUtility::makeInstance(Configuration::class);
+        $pattern = $configuration->getBlacklistPattern();
+
+        // When the pattern is empty (not set), nothing should be excluded, so we just return false.
+        if ($pattern === "") {
+            return false;
+        }
+
+        return preg_match($pattern, $className) > 0;
+    }
+}

--- a/Tests/Unit/Domain/Configuration/ConfigurationTest.php
+++ b/Tests/Unit/Domain/Configuration/ConfigurationTest.php
@@ -16,5 +16,6 @@ class ConfigurationTest extends BaseTestCase
         $this->assertEquals("Production", $configuration->getEnvironment());
         $this->assertEquals("1.0.0", $configuration->getRelease());
         $this->assertEquals(0.0, $configuration->getTracesSampleRate());
+        $this->assertEquals("", $configuration->getBlacklistPattern());
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -8,3 +8,5 @@ environment =
 release =
 # cat=General; type=string; label=Sentry Traces Sample Rate (0.0-1.0)
 traces_sample_rate =
+# cat=General; type=string; label=Regex which matches excluded FQCNs
+blacklist_pattern =


### PR DESCRIPTION
This introduces a new configuration which acts as a regular expression to filter out exceptions before sending them to sentry.